### PR TITLE
filter out certain tracker types

### DIFF
--- a/lib/config.rb
+++ b/lib/config.rb
@@ -27,4 +27,5 @@ class Config
   }.freeze
 
   ISSUE_OUTLIERS = [36319, 40351]
+  TRACKERS_TO_SKIP = ['Epic', 'Feature', 'Support']
 end

--- a/lib/cycle_time.rb
+++ b/lib/cycle_time.rb
@@ -19,7 +19,8 @@ class CycleTime
       feedback: feedback(issue_detail[:journals]),
       done: done(issue_detail[:journals]),
       assignee: issue_detail[:assignee],
-      status: issue_detail[:status]
+      status: issue_detail[:status],
+      tracker: issue_detail[:tracker]
     }
   end
 

--- a/lib/issue_details_fetcher.rb
+++ b/lib/issue_details_fetcher.rb
@@ -22,7 +22,8 @@ class IssueDetailsFetcher
       link: "#{Config.base_url}/issues/#{data['issue']['id']}",
       status: data['issue']['status']['name'],
       journals: data['issue']['journals'],
-      assignee: assigned_to(data)
+      assignee: assigned_to(data),
+      tracker: data['issue']['tracker']['name']
     }
   end
 

--- a/lib/project_metrics.rb
+++ b/lib/project_metrics.rb
@@ -20,7 +20,8 @@ class ProjectMetrics
       csv << ['Issue ID', 'Link', 'Title', 'Analysis', 'Ready to Work', 'In Progress', 'Test', 'Feedback', 'Done', 'Assignee', 'Status']
       issue_details.each do |issue|
         cycle_time = CycleTime.parse issue
-        next if Config::ISSUE_OUTLIERS.include? cycle_time[:id]
+        next if (Config::ISSUE_OUTLIERS.include? cycle_time[:id]) ||
+                (Config::TRACKERS_TO_SKIP.include? cycle_time[:tracker])
         csv << [cycle_time[:id], cycle_time[:link], cycle_time[:subject],
                 cycle_time[:analysis], cycle_time[:ready_to_work],
                 cycle_time[:in_progress], cycle_time[:test],


### PR DESCRIPTION
we started using the Tracker field value of 'Epic' for releases. this lead to an investigation of what the possible values for the Tracker actually are, and then a change to exclude from the metrics Redmine cards with certain values for the Tracker field.